### PR TITLE
Add tick_clear function and call it when the target is no longer valid.

### DIFF
--- a/sensor_0.4.6/control.lua
+++ b/sensor_0.4.6/control.lua
@@ -67,11 +67,15 @@ game.on_event(defines.events.on_tick, function(event)
 				if sensor.target ~= nil and sensor.target.valid then
 					if sensor.base.energy > 0 then
 						tick_once(sensor)
+					--else -- Should output be cleared on loss of power?
+					--	tick_clear(sensor)
 					end
 				elseif sensor.tiles ~= nil then
 					tick_once(sensor)
 				else
-				
+					if sensor.tickFunction ~= nil then
+						tick_clear(sensor)
+					end
 					sensor.target = nil
 					sensor.tickFunction = nil
 					findTarget(sensor)
@@ -121,6 +125,10 @@ function tick_once(sensor)
 		i = i + 1
 	end
 	sensor.output.set_circuit_condition(1, t)
+end
+
+function tick_clear(sensor)
+	sensor.output.set_circuit_condition(1, {parameters = {}})
 end
 		
 function add_detected_items(detected_table, itemName, itemCount)


### PR DESCRIPTION
Sensors facing rail wagons/locomotives do not clear the "detected-train" signals when the train leaves the sensor. This PR fixes that. Should the sensor also clear the output when the sensor loses power, or just maintain last state?
