### PR TITLE
Only create gateforce if it doesn't exist

### DIFF
--- a/actuator_0.4.9/control.lua
+++ b/actuator_0.4.9/control.lua
@@ -26,9 +26,7 @@ function init()
 			insertAt(actuator.base.position, actuator)
 		end
 	end
-	if global.gateforce == nil then
-		global.gateforce = game.create_force("gate")
-	end
+	global.gateforce = game.forces["gate"] or game.create_force("gate")
 end
 
 positions = {}


### PR DESCRIPTION
Removing the mod, saving and readding it causes an error, since the force still exists after the removal and can't be recreated.
